### PR TITLE
M525hd

### DIFF
--- a/m525hd.md
+++ b/m525hd.md
@@ -41,20 +41,20 @@ Interrupt Commands
 
  - **0x0000**: POLL_DEVICE
 	-Sets B to the current state (see below) and C to the latest error since the 
-	 last device poll
+		last device poll
  - **0x0001**: SET_INTERRUPT
 	-Enables interrupts and sets the message to X if X is anything other than 0,
-	 disables interrupts if X is 0.  When interrupts are enabled the m525hd will
-	 trigger an interrupt on the DCPU-16 whenever the state or error message 
-	 changes
+		disables interrupts if X is 0.  When interrupts are enabled the m525hd will
+		trigger an interrupt on the DCPU-16 whenever the state or error message 
+		changes
  - **0x0002**: READ_SECTOR
 	-Reads sector X to DCPU ram starting at Y. Sets B to 1 if reading is possible
-	 and has been started, anything else if reading fails.  Reading is only possible
-	 if the state is STATE_READY or STATE_READY_WP.  Protects against partial reads.
+		and has been started, anything else if reading fails.  Reading is only possible
+		if the state is STATE_READY or STATE_READY_WP.  Protects against partial reads.
  - **0x0003**: WRITE_SECTOR
 	-Writes sector X from DCPU ram starting at Y.  Sets B to 1 if writing is possible
-	 and has been started, anything else if writing fails.  Writing is only possible
-	 if the state is STATE_READY.  Protects against partial writes.
+		and has been started, anything else if writing fails.  Writing is only possible
+		if the state is STATE_READY.  Protects against partial writes.
 
 State Codes
 ----
@@ -74,7 +74,7 @@ Error Codes
 | 0x0002    | ERROR_BAD_ADDRESS | Attempted to read from an sector this drive doesn't contain
 | 0x0003    | ERROR_PROTECTED   | Tried to write to read only drive.
 | 0x0005    | ERROR_BAD_SECTOR  | The requested sector is broken, the data on it is lost.
-| 0xffff	| ERROR_BROKEN	    | Theres been some major software or hardware problem.
+| 0xFFFF	| ERROR_BROKEN	    | Theres been some major software or hardware problem.
 
 Behaviours
 ----

--- a/m525hd.md
+++ b/m525hd.md
@@ -40,19 +40,19 @@ Interrupt Commands
 ----
 
  - **0x0000**: POLL_DEVICE
-	-Sets B to the current state (see below) and C to the latest error since the 
+	- Sets B to the current state (see below) and C to the latest error since the 
 		last device poll
  - **0x0001**: SET_INTERRUPT
-	-Enables interrupts and sets the message to X if X is anything other than 0,
+	- Enables interrupts and sets the message to X if X is anything other than 0,
 		disables interrupts if X is 0.  When interrupts are enabled the m525hd will
 		trigger an interrupt on the DCPU-16 whenever the state or error message 
 		changes
  - **0x0002**: READ_SECTOR
-	-Reads sector X to DCPU ram starting at Y. Sets B to 1 if reading is possible
+	- Reads sector X to DCPU ram starting at Y. Sets B to 1 if reading is possible
 		and has been started, anything else if reading fails.  Reading is only possible
 		if the state is STATE_READY or STATE_READY_WP.  Protects against partial reads.
  - **0x0003**: WRITE_SECTOR
-	-Writes sector X from DCPU ram starting at Y.  Sets B to 1 if writing is possible
+	- Writes sector X from DCPU ram starting at Y.  Sets B to 1 if writing is possible
 		and has been started, anything else if writing fails.  Writing is only possible
 		if the state is STATE_READY.  Protects against partial writes.
 

--- a/m525hd.md
+++ b/m525hd.md
@@ -1,0 +1,86 @@
+Mackapar Media m525hd
+----
+
+```
+                                      .!.
+                                     !!!!!.
+                                  .   '!!!!!.
+                                .!!!.   '!!!!!.
+                              .!!!!!!!.   '!!!!!.
+                            .!!!!!!!!!'   .!!!!!!!.
+                            '!!!!!!!'   .!!!!!!!!!'
+                              '!!!!!.   '!!!!!!!'
+                                '!!!!!.   '!!!'
+                                  '!!!!!.   '
+                                    '!!!!!
+                                      '!'
+
+
+                          M A C K A P A R    M E D I A
+```
+
+|     Item       |   Value    |   Comment
+| -------------: | ---------- | ----------------
+|    Vendor code | 0x2eb37e91 | Mackapar Media
+|      Device ID | 0x525d4ac5 | 5.25" Hard Disk Drive 
+|    Device type | 0x4ac5     | 16 bit fixed Disk Drive
+|        Version | 0x0001     | Dictates Size (5MB, 10MB)
+
+Device Description
+
+Mackapar Medias first foray into fixed storage resulted in the Mackapar Media m525hd.  
+When formatted in 16 bit mode the m525hd has a capacity of 5MB. Data is saved on 4 
+surfaces each containing 64 20-sector tracks. Each sector contains a total of 
+512 words, resulting in a total of 5120 sectors.
+Reads and writes are performed asynchronously, at a read/write speed of 327.7kw/s
+and a Track-to-Track seek time of around 3ms. The average seek time is 80ms with a 
+maximum of 200ms (200 cycles).  
+
+Interrupt Commands
+----
+
+ - **0x0000**: POLL_DEVICE
+	-Sets B to the current state (see below) and C to the latest error since the 
+	 last device poll
+ - **0x0001**: SET_INTERRUPT
+	-Enables interrupts and sets the message to X if X is anything other than 0,
+	 disables interrupts if X is 0.  When interrupts are enabled the m525hd will
+	 trigger an interrupt on the DCPU-16 whenever the state or error message 
+	 changes
+ - **0x0002**: READ_SECTOR
+	-Reads sector X to DCPU ram starting at Y. Sets B to 1 if reading is possible
+	 and has been started, anything else if reading fails.  Reading is only possible
+	 if the state is STATE_READY or STATE_READY_WP.  Protects against partial reads.
+ - **0x0003**: WRITE_SECTOR
+	-Writes sector X from DCPU ram starting at Y.  Sets B to 1 if writing is possible
+	 and has been started, anything else if writing fails.  Writing is only possible
+	 if the state is STATE_READY.  Protects against partial writes.
+
+State Codes
+----
+|   Value   |     Code       |  Description
+| --------: | -------------- | ------------------
+| 0x0000    | STATE_INIT     | The drive is still spinning up.
+| 0x0001    | STATE_READY    | The drive is ready to accept commands.
+| 0x0002    | STATE_READY_WP | The drive is ready but read only.
+| 0x0003    | STATE_BUSY     | The drive is busy either reading, writing or seeking
+
+Error Codes
+----
+|   Value   |     Code          |  Description
+| --------: | ----------------  | ------------------
+| 0x0000    | ERROR_NONE        | There has been no error since the last poll.
+| 0x0001    | ERROR_BUSY        | The drive is busy performing an action.
+| 0x0002    | ERROR_BAD_ADDRESS | Attempted to read from an sector this drive doesn't contain
+| 0x0003    | ERROR_PROTECTED   | Tried to write to read only drive.
+| 0x0005    | ERROR_BAD_SECTOR  | The requested sector is broken, the data on it is lost.
+| 0xffff	| ERROR_BROKEN	    | Theres been some major software or hardware problem.
+
+Behaviours
+----
+ When first powered on the m525hd requires a 15 second interval in which to spin up.
+ Attempting to access the drive during this time should return a state code of STATE_INIT
+ and an Error Code of ERROR_BUSY.  At the end of these 15 seconds the drive should report STATE_READY.
+
+ Maximum seek time is observed when seeking from track 0,1,2,3 (rest) to track 252,253,254,255 (center of drive).
+ Minimum seek time is observed when seeking between adjacent tracks.

--- a/m525hd.md
+++ b/m525hd.md
@@ -55,6 +55,11 @@ Interrupt Commands
 	- Writes sector X from DCPU ram starting at Y.  Sets B to 1 if writing is possible
 		and has been started, anything else if writing fails.  Writing is only possible
 		if the state is STATE_READY.  Protects against partial writes.
+- **0x0004**: SPIN_DOWN
+	- Parks the heads and spins down the drive to conserve power. 
+- **0x0005**: SPIN_UP
+	- Spins up the drive to make ready for reading/writing.  The drive will need a 15 
+		second interval to reach the proper speed. 
 
 State Codes
 ----
@@ -63,8 +68,8 @@ State Codes
 | 0x0000    | STATE_INIT     | The drive is still spinning up.
 | 0x0001    | STATE_READY    | The drive is ready to accept commands.
 | 0x0002    | STATE_READY_WP | The drive is ready but read only.
-| 0x0003    | STATE_BUSY     | The drive is busy either reading, writing or seeking
-
+| 0x0003    | STATE_BUSY     | The drive is busy either reading, writing or seeking.
+| 0x0004	| STATE_PARKED   | The drive has been spun down and needs to be restarted.
 Error Codes
 ----
 |   Value   |     Code          |  Description
@@ -73,14 +78,15 @@ Error Codes
 | 0x0001    | ERROR_BUSY        | The drive is busy performing an action.
 | 0x0002    | ERROR_BAD_ADDRESS | Attempted to read from an sector this drive doesn't contain
 | 0x0003    | ERROR_PROTECTED   | Tried to write to read only drive.
+| 0x0004    | ERROR_PARKED      | Attempted to read/write from a spun down drive.
 | 0x0005    | ERROR_BAD_SECTOR  | The requested sector is broken, the data on it is lost.
 | 0xFFFF	| ERROR_BROKEN	    | Theres been some major software or hardware problem.
 
 Behaviours
 ----
- When first powered on the m525hd requires a 15 second interval in which to spin up.
- Attempting to access the drive during this time should return a state code of STATE_INIT
- and an Error Code of ERROR_BUSY.  At the end of these 15 seconds the drive should report STATE_READY.
+ When first powered on (or after being spun down) the m525hd requires a 15 second interval in which to spin up.
+ Attempting to access the drive during this time should return a state code of STATE_INIT and an Error Code of 
+ ERROR_BUSY.  At the end of these 15 seconds the drive should report STATE_READY.
 
  Maximum seek time is observed when seeking from track 0,1,2,3 (rest) to track 252,253,254,255 (center of drive).
  Minimum seek time is observed when seeking between adjacent tracks.

--- a/m525hd.md
+++ b/m525hd.md
@@ -65,18 +65,20 @@ State Codes
 ----
 |   Value   |     Code       |  Description
 | --------: | -------------- | ------------------
-| 0x0000    | STATE_INIT     | The drive is still spinning up.
 | 0x0001    | STATE_READY    | The drive is ready to accept commands.
 | 0x0002    | STATE_READY_WP | The drive is ready but read only.
 | 0x0003    | STATE_BUSY     | The drive is busy either reading, writing or seeking.
 | 0x0004	| STATE_PARKED   | The drive has been spun down and needs to be restarted.
+| 0x0005	| STATE_PARKED_WP| The drive has been spun down and is write protected.
+| 0x0006	| STATE_INIT     | The drive is still spinning up.
+| 0x0007	| STATE_INIT_WP	 | The drive is still spinning up and is write protected.
 Error Codes
 ----
 |   Value   |     Code          |  Description
 | --------: | ----------------  | ------------------
 | 0x0000    | ERROR_NONE        | There has been no error since the last poll.
 | 0x0001    | ERROR_BUSY        | The drive is busy performing an action.
-| 0x0002    | ERROR_BAD_ADDRESS | Attempted to read from an sector this drive doesn't contain
+| 0x0002    | ERROR_BAD_ADDRESS | Attempted to read from a sector this drive doesn't contain
 | 0x0003    | ERROR_PROTECTED   | Tried to write to read only drive.
 | 0x0004    | ERROR_PARKED      | Attempted to read/write from a spun down drive.
 | 0x0005    | ERROR_BAD_SECTOR  | The requested sector is broken, the data on it is lost.

--- a/m525hd.md
+++ b/m525hd.md
@@ -55,9 +55,9 @@ Interrupt Commands
 	- Writes sector X from DCPU ram starting at Y.  Sets B to 1 if writing is possible
 		and has been started, anything else if writing fails.  Writing is only possible
 		if the state is STATE_READY.  Protects against partial writes.
-- **0x0004**: SPIN_DOWN
+ - **0x0004**: SPIN_DOWN
 	- Parks the heads and spins down the drive to conserve power. 
-- **0x0005**: SPIN_UP
+ - **0x0005**: SPIN_UP
 	- Spins up the drive to make ready for reading/writing.  The drive will need a 15 
 		second interval to reach the proper speed. 
 

--- a/m525hd.md
+++ b/m525hd.md
@@ -87,8 +87,8 @@ Error Codes
 Behaviours
 ----
  When first powered on (or after being spun down) the m525hd requires a 15 second interval in which to spin up.
- Attempting to access the drive during this time should return a state code of STATE_INIT and an Error Code of 
- ERROR_BUSY.  At the end of these 15 seconds the drive should report STATE_READY.
+ Attempting to access the drive during this time should return a state code of STATE_INIT(_WP) and an Error Code of 
+ ERROR_BUSY.  At the end of these 15 seconds the drive should report STATE_READY(_WP).
 
  Maximum seek time is observed when seeking from track 0,1,2,3 (rest) to track 252,253,254,255 (center of drive).
  Minimum seek time is observed when seeking between adjacent tracks.


### PR DESCRIPTION
Initial Spec laid out for a fixed HDD.  Interface is a superset of the m35fd interface, with two additional commands at interrupts 4 and 5.  Many state and error codes are shared between this and the m35fd, with new ones added where floppy specific codes didn't make sense.